### PR TITLE
:zap: Clear package_id information

### DIFF
--- a/all/conanfile.py
+++ b/all/conanfile.py
@@ -29,6 +29,7 @@ class LLVMToolchainPackage(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     package_type = "application"
     build_policy = "missing"
+    upload_policy = "skip"
     short_paths = True
 
     options = {
@@ -494,25 +495,6 @@ class LLVMToolchainPackage(ConanFile):
                     self.setup_arm_cortex_m()
 
     def package_id(self):
-        # All options should be removed as none of them should impact the
-        # package id hash. These options are only used for delivering command
-        # line arguments via the package_info.
-        del self.info.options.default_arch
-        del self.info.options.lto
-        del self.info.options.function_sections
-        del self.info.options.data_sections
-        del self.info.options.gc_sections
-        del self.info.options.use_semihosting
-        # Remove any compiler or build_type settings from recipe hash
-        del self.info.settings.compiler
-        del self.info.settings.build_type
-
-        # Normalize Cortex-M variants to share the same package_id
-        if self.settings_target:
-            target_arch = str(self.settings_target.get_safe("arch") or "")
-            target_os = str(self.settings_target.get_safe("os") or "")
-
-            # All Cortex-M variants use the SAME binary - normalize them
-            if target_os == "baremetal" and target_arch.startswith("cortex-m"):
-                # Use conf system to modify the hash for the package ID
-                self.info.conf.define("user.llvm:target_family", "cortex-m")
+        # Clear everything - this is a recipe-only package
+        # Users build locally by downloading binaries for their platform
+        self.info.clear()


### PR DESCRIPTION
As we make additional revisions to this library, we get the problem below:

```
======== Computing necessary packages ========
arm-gnu-toolchain/14.3: Main binary package '2555de54186fe7fa914a0d897f3f9cd69cdf509a' missing
arm-gnu-toolchain/14.3: Checking 13 compatible configurations
arm-gnu-toolchain/14.3: Compatible configurations not found in cache, checking servers
arm-gnu-toolchain/14.3: '1bf1f10da95030bc7e12d66c27c90e34d256dbfd': compiler.cppstd=98
arm-gnu-toolchain/14.3: 'bf808f4c83d1f31e0dea0d17297c118128737f04': compiler.cppstd=gnu98
arm-gnu-toolchain/14.3: 'ddae73980ff58f28baee10301d98483cee6520c0': compiler.cppstd=11
arm-gnu-toolchain/14.3: '5aab5a35bf7a010ac3f49b9f72859c0567879645': compiler.cppstd=gnu11
arm-gnu-toolchain/14.3: 'fc74a635f96406536802cffca2bc99fd95077a79': compiler.cppstd=14
arm-gnu-toolchain/14.3: '53eb7f790c2b3ccb0b5d735995fec7bb729a1866': compiler.cppstd=gnu14
arm-gnu-toolchain/14.3: 'fbdef5c305213b2fe0b64f21f8ecb128d2190d8d': compiler.cppstd=17
arm-gnu-toolchain/14.3: '2af57a5180150f71c11616b7e9ed1926f1dbc17d': compiler.cppstd=20
arm-gnu-toolchain/14.3: '30a01124579cd5eee0c375ef9f00bb539bbf94ee': compiler.cppstd=gnu20
arm-gnu-toolchain/14.3: '79292c7a18ebbbfb1c26e6b2436db03aff0218e9': compiler.cppstd=23
arm-gnu-toolchain/14.3: '4538fdebe7ecdfb7d9ffdb5d80e9d2a274d6e9b7': compiler.cppstd=gnu23
arm-gnu-toolchain/14.3: '89a9093101a3eec5287a679f18eebf47bb5f8af8': compiler.cppstd=26
arm-gnu-toolchain/14.3: '860ce0b7b5f40d48094333d12b84a3028fba67c2': compiler.cppstd=gnu26
arm-gnu-toolchain/14.3: No compatible configuration found
arm-gnu-toolchain/14.3: Building package from source as defined by build_policy='missing'
```

This is an example from the `arm-gnu-toolchain` library. It never keeps prebuilt binaries. Just a recipe, but due to not clearing all of the package_id information, users begin a lengthy exchange with the toolchain as it looks for a compatible version and eventually finds none. This grows with revisions. With this change, conan immediately fetches either the latest revision.