### PR TITLE
Revert ":zap: Clear package_id information"

### DIFF
--- a/all/conanfile.py
+++ b/all/conanfile.py
@@ -29,6 +29,7 @@ class LLVMToolchainPackage(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     package_type = "application"
     build_policy = "missing"
+    upload_policy = "skip"
     short_paths = True
 
     options = {

--- a/all/conanfile.py
+++ b/all/conanfile.py
@@ -29,7 +29,6 @@ class LLVMToolchainPackage(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     package_type = "application"
     build_policy = "missing"
-    upload_policy = "skip"
     short_paths = True
 
     options = {
@@ -495,6 +494,25 @@ class LLVMToolchainPackage(ConanFile):
                     self.setup_arm_cortex_m()
 
     def package_id(self):
-        # Clear everything - this is a recipe-only package
-        # Users build locally by downloading binaries for their platform
-        self.info.clear()
+        # All options should be removed as none of them should impact the
+        # package id hash. These options are only used for delivering command
+        # line arguments via the package_info.
+        del self.info.options.default_arch
+        del self.info.options.lto
+        del self.info.options.function_sections
+        del self.info.options.data_sections
+        del self.info.options.gc_sections
+        del self.info.options.use_semihosting
+        # Remove any compiler or build_type settings from recipe hash
+        del self.info.settings.compiler
+        del self.info.settings.build_type
+
+        # Normalize Cortex-M variants to share the same package_id
+        if self.settings_target:
+            target_arch = str(self.settings_target.get_safe("arch") or "")
+            target_os = str(self.settings_target.get_safe("os") or "")
+
+            # All Cortex-M variants use the SAME binary - normalize them
+            if target_os == "baremetal" and target_arch.startswith("cortex-m"):
+                # Use conf system to modify the hash for the package ID
+                self.info.conf.define("user.llvm:target_family", "cortex-m")


### PR DESCRIPTION
Reverts libhal/llvm-toolchain#34

Putting this here just in case this was a big mistake. I didn't check that the toolchain differentiates between building for cortex m processors and host OSes.