### PR TITLE
:bug: (patch) Update host_profile format and remove redundant CMake system name settings

### DIFF
--- a/.github/workflows/20.yml
+++ b/.github/workflows/20.yml
@@ -74,7 +74,7 @@ jobs:
       display_name: Linux x86_64 → Cortex-M4F
       version: ${{ inputs.version }}
       os: ubuntu-24.04
-      host_profile: cortex-m4f
+      host_profile: -pr cortex-m4f
 
   verify-linux-arm-cortex-m4:
     uses: ./.github/workflows/verify.yml
@@ -82,7 +82,7 @@ jobs:
       display_name: Linux ARM → Cortex-M4
       version: ${{ inputs.version }}
       os: ubuntu-24.04-arm
-      host_profile: cortex-m4
+      host_profile: -pr cortex-m4
 
   verify-macos-14-arm-cortex-m4f:
     uses: ./.github/workflows/verify.yml
@@ -90,7 +90,7 @@ jobs:
       display_name: macOS 14 ARM → Cortex-M4F
       version: ${{ inputs.version }}
       os: macos-14
-      host_profile: cortex-m4f
+      host_profile: -pr cortex-m4f
 
   verify-macos-15-arm-cortex-m4f:
     uses: ./.github/workflows/verify.yml
@@ -98,7 +98,7 @@ jobs:
       display_name: macOS 15 ARM → Cortex-M4F
       version: ${{ inputs.version }}
       os: macos-15
-      host_profile: cortex-m4f
+      host_profile: -pr cortex-m4f
 
   verify-macos-15-intel-cortex-m4f:
     uses: ./.github/workflows/verify.yml
@@ -106,7 +106,7 @@ jobs:
       display_name: macOS 15 Intel → Cortex-M4F
       version: ${{ inputs.version }}
       os: macos-15-intel
-      host_profile: cortex-m4f
+      host_profile: -pr cortex-m4f
 
   verify-windows-x86_64-cortex-m33f:
     uses: ./.github/workflows/verify.yml
@@ -114,7 +114,7 @@ jobs:
       display_name: Windows x86_64 → Cortex-M33F
       version: ${{ inputs.version }}
       os: windows-latest
-      host_profile: cortex-m33f
+      host_profile: -pr cortex-m33f
 
   upload-package:
     needs:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -73,14 +73,14 @@ jobs:
 
       - name: 📦 Create LLVM Toolchain Package (cross build)
         if: ${{ inputs.host_profile != '' }}
-        run: conan create all --version=${{ inputs.version }} --build-require --build=cmake --build=missing:cmake/* -pr:h llvm-${{ inputs.version }} $HOST_PROFILE --build=make --build=missing:make/*
+        run: conan create all -pr:h llvm-${{ inputs.version }} ${{ inputs.host_profile }} --version=${{ inputs.version }} --build-require --build=cmake --build=missing:cmake/* --build=make --build=missing:make/*
 
       - name: ⚙️ Build/Install ninja from scratch using LLVM for build platform
         run: >
           conan install --tool-requires="ninja/1.13.2" --build="ninja/*" -pr:a llvm-${{ inputs.version }} --build=cmake --build=missing:cmake/*
 
       - name: 📦 Build C++ demo using  LLVM toolchain
-        run: conan build demos/cpp -pr:a llvm-${{ inputs.version }} $HOST_PROFILE
+        run: conan build demos/cpp -pr:a llvm-${{ inputs.version }} ${{ inputs.host_profile }}
 
       - name: 📦 Build C++ modules demo using LLVM toolchain
-        run: conan build demos/cpp-modules -pr:a llvm-${{ inputs.version }} $HOST_PROFILE
+        run: conan build demos/cpp-modules -pr:a llvm-${{ inputs.version }} ${{ inputs.host_profile }}

--- a/all/conanfile.py
+++ b/all/conanfile.py
@@ -428,10 +428,6 @@ class LLVMToolchainPackage(ConanFile):
     def setup_linux(self):
         self.cpp_info.libdirs = []
 
-        # Explicitly set system name for CMake
-        self.conf_info.define(
-            "tools.cmake.cmaketoolchain:system_name", "Linux")
-
         library_path = ""
         if self.settings.arch == "x86_64":
             library_path = self._lib_path / "x86_64-unknown-linux-gnu"
@@ -458,17 +454,9 @@ class LLVMToolchainPackage(ConanFile):
         # unused.
         self.conf_info.append("tools.gnu:disable_flags", 'libcxx')
 
-        # Ensure CMake knows this is a Windows build
-        self.conf_info.define(
-            "tools.cmake.cmaketoolchain:system_name", "Windows")
-
     def setup_mac_osx(self):
         # Disable Conan's automatic library directories
         self.cpp_info.libdirs = []
-
-        # Ensure CMake knows this is a Mac/Darwin build
-        self.conf_info.define(
-            "tools.cmake.cmaketoolchain:system_name", "Darwin")
 
     def package_info(self):
         self.conf_info.define("tools.build:compiler_executables", {


### PR DESCRIPTION


The changes include:

1. Updating host_profile format from cortex-m4f to -pr cortex-m4f in workflow files
2. Reordering parameters in conan commands for better clarity
3. Removing redundant CMake system name settings that were previously defined in conanfile.py causing builds to look like they are cross compiling for native builds.

These changes improve the consistency of how host profiles are specified and clean up unnecessary configuration definitions.